### PR TITLE
throw on `.next()` when `windows` cannot yield at least 1 full window

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -49,7 +49,7 @@ copyright: false
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
         1. If _value_ is ~done~, then
-          1. If the number of elements in _buffer_ &lt; ℝ(_windowSize_), throw a *TypeError* exception.
+          1. If _buffer_ is not empty and the number of elements in _buffer_ &lt; ℝ(_windowSize_), throw a *TypeError* exception.
           1. Return ReturnCompletion(*undefined*).
         1. Append _value_ to _buffer_.
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then

--- a/spec.emu
+++ b/spec.emu
@@ -48,7 +48,9 @@ copyright: false
       1. Let _buffer_ be a new empty List.
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
-        1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+        1. If _value_ is ~done~, then
+          1. If the number of elements in _buffer_ &lt; ℝ(_windowSize_), throw a *TypeError* exception.
+          1. Else, return ReturnCompletion(*undefined*).
         1. Append _value_ to _buffer_.
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
           1. Let _completion_ be Completion(Yield(CreateArrayFromList(_buffer_))).

--- a/spec.emu
+++ b/spec.emu
@@ -50,7 +50,7 @@ copyright: false
         1. Let _value_ be ? IteratorStepValue(_iterated_).
         1. If _value_ is ~done~, then
           1. If the number of elements in _buffer_ &lt; ℝ(_windowSize_), throw a *TypeError* exception.
-          1. Else, return ReturnCompletion(*undefined*).
+          1. Return ReturnCompletion(*undefined*).
         1. Append _value_ to _buffer_.
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
           1. Let _completion_ be Completion(Yield(CreateArrayFromList(_buffer_))).


### PR DESCRIPTION
This is one of four possible behaviours.

1. yield no values (empty iterator): current behaviour
2. throw on `.next()`: this PR
3. yield a single undersized window: #15
4. pad with `undefined`: #16

Closes #13.