### PR TITLE
yield an undersized window when windows cannot yield at least 1 full one

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -49,7 +49,7 @@ copyright: false
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
         1. If _value_ is ~done~, then
-          1. If the number of elements in _buffer_ &lt; ℝ(_windowSize_), perform ? Yield(CreateArrayFromList(_buffer_)).
+          1. If _buffer_ is not empty and the number of elements in _buffer_ &lt; ℝ(_windowSize_), perform ? Yield(CreateArrayFromList(_buffer_)).
           1. Return ReturnCompletion(*undefined*).
         1. Append _value_ to _buffer_.
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then


### PR DESCRIPTION
This is one of four possible behaviours.

1. yield no values (empty iterator): current behaviour
2. throw on `.next()`: #14
3. yield a single undersized window: this PR
4. pad with `undefined`: #16

Closes #13.