### PR TITLE
pad an undersized first window with undefined

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -48,7 +48,12 @@ copyright: false
       1. Let _buffer_ be a new empty List.
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
-        1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
+        1. If _value_ is ~done~, then
+          1. If _buffer_ is not empty and the number of elements in _buffer_ &lt; ℝ(_windowSize_), then
+            1. Repeat, while the number of elements in _buffer_ &lt; ℝ(_windowSize_),
+              1. Append *undefined* to _buffer_.
+            1. Perform ? Yield(CreateArrayFromList(_buffer_)).
+          1. Return ReturnCompletion(*undefined*).
         1. Append _value_ to _buffer_.
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
           1. Let _completion_ be Completion(Yield(CreateArrayFromList(_buffer_))).


### PR DESCRIPTION
This is one of four possible behaviours.

1. yield no values (empty iterator): current behaviour
2. throw on `.next()`: #14
3. yield a single undersized window: #15
4. pad with `undefined`: this PR

Closes #13.