### PR TITLE
add Iterator.prototype.sliding, as per May 2025 plenary

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -39,6 +39,35 @@ copyright: false
   </emu-alg>
 </emu-clause>
 
+<emu-clause id="sec-iterator.prototype.sliding">
+  <h1>Iterator.prototype.sliding ( _windowSize_ )</h1>
+  <p>This method performs the following steps when called:</p>
+  <emu-alg>
+    1. Let _O_ be the *this* value.
+    1. If _O_ is not an Object, throw a *TypeError* exception.
+    1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
+    1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
+      1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
+      1. Return ? IteratorClose(_iterated_, _error_).
+    1. Set _iterated_ to ? GetIteratorDirect(_O_).
+    1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _windowSize_ and performs the following steps when called:
+      1. Let _buffer_ be a new empty List.
+      1. Repeat,
+        1. Let _value_ be ? IteratorStepValue(_iterated_).
+        1. If _value_ is ~done~, then
+          1. If _buffer_ is not empty and the number of elements in _buffer_ &lt; ℝ(_windowSize_), perform ? Yield(CreateArrayFromList(_buffer_)).
+          1. Return ReturnCompletion(*undefined*).
+        1. Append _value_ to _buffer_.
+        1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
+          1. Let _completion_ be Completion(Yield(CreateArrayFromList(_buffer_))).
+          1. IfAbruptCloseIterator(_completion_, _iterated_).
+          1. Remove the first element from _buffer_.
+    1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
+    1. Set _result_.[[UnderlyingIterators]] to « _iterated_ ».
+    1. Return _result_.
+  </emu-alg>
+</emu-clause>
+
 <emu-clause id="sec-iterator.prototype.windows">
   <h1>Iterator.prototype.windows ( _windowSize_ )</h1>
   <p>This method performs the following steps when called:</p>


### PR DESCRIPTION
Name based on Scala's [Seq#sliding](https://www.scala-lang.org/api/3.x/scala/collection/immutable/Seq.html#sliding-fffffbef). Implementation is identical to the one proposed in #15. Closes #14. Closes #15. Closes #16.