### PR TITLE
replace extra method with string parameter

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -39,8 +39,8 @@ copyright: false
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-iterator.prototype.sliding">
-  <h1>Iterator.prototype.sliding ( _windowSize_ )</h1>
+<emu-clause id="sec-iterator.prototype.windows">
+  <h1>Iterator.prototype.windows ( _windowSize_ [ , _undersized_ ] )</h1>
   <p>This method performs the following steps when called:</p>
   <emu-alg>
     1. Let _O_ be the *this* value.
@@ -49,43 +49,19 @@ copyright: false
     1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
+    1. If _undersized_ is *undefined*, set _undersized_ to *"skip"*.
+    1. If _undersized_ is neither *"skip"* nor *"truncate"*, then
+      1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+      1. Return ? IteratorClose(_iterated_, _error_).
     1. Set _iterated_ to ? GetIteratorDirect(_O_).
-    1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _windowSize_ and performs the following steps when called:
+    1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_, _windowSize_, and _undersized_ and performs the following steps when called:
       1. Let _buffer_ be a new empty List.
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
         1. If _value_ is ~done~, then
-          1. If _buffer_ is not empty and the number of elements in _buffer_ &lt; ℝ(_windowSize_), then
+          1. If _undersized_ is *"truncate"*, _buffer_ is not empty, and the number of elements in _buffer_ &lt; ℝ(_windowSize_), then
             1. Perform Completion(Yield(CreateArrayFromList(_buffer_))).
           1. Return ReturnCompletion(*undefined*).
-        1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
-          1. Remove the first element from _buffer_.
-        1. Append _value_ to _buffer_.
-        1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
-          1. Let _completion_ be Completion(Yield(CreateArrayFromList(_buffer_))).
-          1. IfAbruptCloseIterator(_completion_, _iterated_).
-    1. Let _result_ be CreateIteratorFromClosure(_closure_, *"Iterator Helper"*, %IteratorHelperPrototype%, « [[UnderlyingIterators]] »).
-    1. Set _result_.[[UnderlyingIterators]] to « _iterated_ ».
-    1. Return _result_.
-  </emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-iterator.prototype.windows">
-  <h1>Iterator.prototype.windows ( _windowSize_ )</h1>
-  <p>This method performs the following steps when called:</p>
-  <emu-alg>
-    1. Let _O_ be the *this* value.
-    1. If _O_ is not an Object, throw a *TypeError* exception.
-    1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-    1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
-      1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
-      1. Return ? IteratorClose(_iterated_, _error_).
-    1. Set _iterated_ to ? GetIteratorDirect(_O_).
-    1. Let _closure_ be a new Abstract Closure with no parameters that captures _iterated_ and _windowSize_ and performs the following steps when called:
-      1. Let _buffer_ be a new empty List.
-      1. Repeat,
-        1. Let _value_ be ? IteratorStepValue(_iterated_).
-        1. If _value_ is ~done~, return ReturnCompletion(*undefined*).
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then
           1. Remove the first element from _buffer_.
         1. Append _value_ to _buffer_.

--- a/spec.emu
+++ b/spec.emu
@@ -49,8 +49,8 @@ copyright: false
     1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
-    1. If _undersized_ is *undefined*, set _undersized_ to *"skip"*.
-    1. If _undersized_ is neither *"skip"* nor *"truncate"*, then
+    1. If _undersized_ is *undefined*, set _undersized_ to *"discard"*.
+    1. If _undersized_ is neither *"discard"* nor *"truncate"*, then
       1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
     1. Set _iterated_ to ? GetIteratorDirect(_O_).

--- a/spec.emu
+++ b/spec.emu
@@ -49,8 +49,8 @@ copyright: false
     1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
-    1. If _undersized_ is *undefined*, set _undersized_ to *"discard"*.
-    1. If _undersized_ is neither *"discard"* nor *"truncate"*, then
+    1. If _undersized_ is *undefined*, set _undersized_ to *"only full"*.
+    1. If _undersized_ is neither *"only full"* nor *"allow partial"*, then
       1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
     1. Set _iterated_ to ? GetIteratorDirect(_O_).
@@ -59,7 +59,7 @@ copyright: false
       1. Repeat,
         1. Let _value_ be ? IteratorStepValue(_iterated_).
         1. If _value_ is ~done~, then
-          1. If _undersized_ is *"truncate"*, _buffer_ is not empty, and the number of elements in _buffer_ &lt; ℝ(_windowSize_), then
+          1. If _undersized_ is *"allow partial"*, _buffer_ is not empty, and the number of elements in _buffer_ &lt; ℝ(_windowSize_), then
             1. Perform Completion(Yield(CreateArrayFromList(_buffer_))).
           1. Return ReturnCompletion(*undefined*).
         1. If the number of elements in _buffer_ is ℝ(_windowSize_), then


### PR DESCRIPTION
I really don't like having two almost identical methods which differ only in their handling of an edge case. This PR removes `sliding` and adds a string parameter to `windows` which controls the behavior in the case of an undersized iterator, with possible values `"discard"` (the default) or `"truncate"` (the previous behavior for `sliding`). Feel free to bikeshed the values if you have strong opinions. I left out `"throw"` but I guess it's also a valid thing to want (edit: https://github.com/tc39/proposal-iterator-chunking/pull/25).

I've chosen to go with a string argument instead of a boolean so that we can later [turn this into an options bag](https://github.com/tc39/proposal-iterator-chunking/issues/23#issuecomment-3104691673) if we really feel the need. Boolean would also be fine but makes it harder to do that change (because [we said](https://github.com/tc39/how-we-work/blob/56550835b23bca5689835cf37daa873fe75ba9e2/normative-conventions.md#avoid-coercing-arguments-to-types-other-than-boolean) we'd allow coercion to boolean).

Fixes https://github.com/tc39/proposal-iterator-chunking/issues/23 (by causing it not to be a problem).