### PR TITLE
throw a TypeError for non-Numbers and non-integral Numbers

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -16,7 +16,10 @@ copyright: false
     1. Let _O_ be the *this* value.
     1. If _O_ is not an Object, throw a *TypeError* exception.
     1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-    1. If _chunkSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
+    1. If _chunkSize_ is not an integral Number, then
+      1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+      1. Return ? IteratorClose(_iterated_, _error_).
+    1. If _chunkSize_ is not in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
     1. Set _iterated_ to ? GetIteratorDirect(_O_).
@@ -46,7 +49,10 @@ copyright: false
     1. Let _O_ be the *this* value.
     1. If _O_ is not an Object, throw a *TypeError* exception.
     1. Let _iterated_ be the Iterator Record { [[Iterator]]: _O_, [[NextMethod]]: *undefined*, [[Done]]: *false* }.
-    1. If _windowSize_ is not an integral Number in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
+    1. If _windowSize_ is not an integral Number, then
+      1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+      1. Return ? IteratorClose(_iterated_, _error_).
+    1. If _windowSize_ is not in the inclusive interval from *1*<sub>𝔽</sub> to 𝔽(2<sup>32</sup> - 1), then
       1. Let _error_ be ThrowCompletion(a newly created *RangeError* object).
       1. Return ? IteratorClose(_iterated_, _error_).
     1. If _undersized_ is *undefined*, set _undersized_ to *"only-full"*.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,12 +20,10 @@ function* chunksImpl<A>(iter: Iterator<A>, chunkSize: number): Generator<Array<A
 
 function chunks<A>(this: Iterator<A>, chunkSize: number): Generator<Array<A>>
 function chunks(this: unknown, chunkSize: unknown): Generator<unknown> {
-  if (
-    typeof chunkSize !== 'number'
-    || chunkSize <= 0
-    || Math.floor(chunkSize) !== chunkSize
-    || chunkSize >= Math.pow(2, 53)
-  ) {
+  if (typeof chunkSize !== 'number' || Math.floor(chunkSize) !== chunkSize) {
+    throw new TypeError;
+  }
+  if (chunkSize <= 0 || chunkSize >= Math.pow(2, 53)) {
     throw new RangeError;
   }
   return chunksImpl(this as Iterator<unknown>, chunkSize)
@@ -49,12 +47,10 @@ function* windowsImpl<A>(iter: Iterator<A>, windowSize: number, undersized: 'onl
 
 function windows<A>(this: Iterator<A>, windowSize: number, undersized?: 'only-full' | 'allow-partial'): Generator<Array<A>>
 function windows(this: unknown, windowSize: unknown, undersized?: unknown): Generator<unknown> {
-  if (
-    typeof windowSize !== 'number'
-    || windowSize <= 0
-    || Math.floor(windowSize) !== windowSize
-    || windowSize >= Math.pow(2, 53)
-  ) {
+  if (typeof windowSize !== 'number' || Math.floor(windowSize) !== windowSize) {
+    throw new TypeError;
+  }
+  if (windowSize <= 0 || windowSize >= Math.pow(2, 53)) {
     throw new RangeError;
   }
   if (undersized === undefined) {

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -38,18 +38,24 @@ test('chunks', async t => {
 
   assert.throws(() => {
     nats(1).chunks();
-  }, RangeError)
+  }, TypeError)
   assert.throws(() => {
     nats(1).chunks([2]);
-  }, RangeError)
+  },TypeError)
+  assert.throws(() => {
+    nats(1).chunks(1.5);
+  }, TypeError)
+  assert.throws(() => {
+    nats(1).chunks('1');
+  }, TypeError)
+  assert.throws(() => {
+    nats(1).chunks(NaN);
+  }, TypeError)
   assert.throws(() => {
     nats(1).chunks(0);
   }, RangeError)
   assert.throws(() => {
     nats(1).chunks(-1);
-  }, RangeError)
-  assert.throws(() => {
-    nats(1).chunks(1.5);
   }, RangeError)
   assert.throws(() => {
     nats(1).chunks(Math.pow(2, 53));
@@ -144,23 +150,62 @@ test('windows', async t => {
 
   assert.throws(() => {
     nats(1).windows()
-  }, RangeError);
+  }, TypeError);
   assert.throws(() => {
     nats(1).windows(undefined, "only-full")
-  }, RangeError);
+  }, TypeError);
   assert.throws(() => {
     nats(1).windows(undefined, "allow-partial")
-  }, RangeError);
+  }, TypeError);
 
   assert.throws(() => {
     nats(1).windows([2]);
-  }, RangeError);
+  }, TypeError);
   assert.throws(() => {
     nats(1).windows([2], "only-full");
-  }, RangeError);
+  }, TypeError);
   assert.throws(() => {
     nats(1).windows([2], "allow-partial");
-  }, RangeError);
+  }, TypeError);
+
+  assert.throws(() => {
+    nats(1).windows(1.5);
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(1.5, undefined);
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(1.5, "only-full");
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(1.5, "allow-partial");
+  }, TypeError);
+
+  assert.throws(() => {
+    nats(1).windows('1');
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows('1', undefined);
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows('1', "only-full");
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows('1', "allow-partial");
+  }, TypeError);
+
+  assert.throws(() => {
+    nats(1).windows(NaN);
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(NaN, undefined);
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(NaN, "only-full");
+  }, TypeError);
+  assert.throws(() => {
+    nats(1).windows(NaN, "allow-partial");
+  }, TypeError);
 
   assert.throws(() => {
     nats(1).windows(0);
@@ -186,19 +231,6 @@ test('windows', async t => {
   }, RangeError);
   assert.throws(() => {
     nats(1).windows(-1, "allow-partial");
-  }, RangeError);
-
-  assert.throws(() => {
-    nats(1).windows(1.5);
-  }, RangeError);
-  assert.throws(() => {
-    nats(1).windows(1.5, undefined);
-  }, RangeError);
-  assert.throws(() => {
-    nats(1).windows(1.5, "only-full");
-  }, RangeError);
-  assert.throws(() => {
-    nats(1).windows(1.5, "allow-partial");
   }, RangeError);
 
   assert.throws(() => {


### PR DESCRIPTION
A TypeError is better than a RangeError for these values. Matches what we're doing for the second parameter of `Iterator.prototype.includes`: https://tc39.es/proposal-iterator-includes/.