### PR TITLE
add helper for running test262 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 /lib
 /dist
+evaluated-test262.js

--- a/run-test262.mjs
+++ b/run-test262.mjs
@@ -1,0 +1,43 @@
+// assumes test262 is checked out in ../test262
+
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { stripTypeScriptTypes } from 'node:module';
+
+const FEATURE = 'iterator-chunking';
+
+let testDir = '../test262/test/built-ins/Iterator';
+let files = fs.readdirSync(testDir, { recursive: true });
+
+let src = stripTypeScriptTypes(fs.readFileSync('src/index.ts', 'utf8'));
+
+let harness =
+  src +
+[
+  '../test262/harness/assert.js',
+  '../test262/harness/compareArray.js',
+  '../test262/harness/isConstructor.js',
+  '../test262/harness/iteratorZipUtils.js',
+  '../test262/harness/propertyHelper.js',
+  '../test262/harness/proxyTrapsHelper.js',
+  '../test262/harness/testTypedArray.js',
+  '../test262/harness/wellKnownIntrinsicObjects.js',
+].map(x => fs.readFileSync(x, 'utf8')).join('\n') + `
+var $DETACHBUFFER = buff => buff.transfer();
+class Test262Error extends Error {}
+`;
+
+for (let file of files) {
+  if (!file.endsWith('.js')) continue;
+  let basic = fs.readFileSync(testDir + '/' + file, 'utf8');
+  if (!basic.includes(FEATURE)) continue;
+  console.log(testDir + '/' + file);
+  let contents = harness + '\n(function(){ ' + basic + '})()';
+  try {
+    vm.runInContext(contents, vm.createContext({ console }));
+  } catch (e) {
+    fs.writeFileSync('evaluated-test262.js', contents, 'utf8');
+    console.log('evaluated-test262.js')
+    throw e;
+  }
+}


### PR DESCRIPTION
Basically the same helper as [for join](https://github.com/tc39/proposal-joint-iteration/blob/main/run-test262.mjs), but stripping TS types since this impl uses typescript.

This fails on https://github.com/tc39/test262/pull/5011. Probably want to take a look at that.